### PR TITLE
重写登录注册逻辑，实现 MySql 连接，重写用户信息结构

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,25 @@
+package config
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+)
+
+type Configuration struct {
+	Mysql string `json:"Mysql"`
+}
+
+var Config Configuration // 实例化一个 Configuration 类对象
+
+// ReadConfig 读取配置文件
+func ReadConfig(fileName string) {
+	configFile, err := ioutil.ReadFile(fileName) // 读取文件内容并将其作为字节切片返回
+	if err != nil {
+		log.Fatalf("Error reading config file: %v", err)
+	}
+	err = json.Unmarshal(configFile, &Config) // 将解析后的 JSON 式数据存储在 Config 对象中
+	if err != nil {
+		log.Fatalf("Error parsing config file: %v", err)
+	}
+}

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -1,0 +1,3 @@
+{
+  "Mysql": "root:123456@tcp(127.0.0.1:3306)/tinytiktok?charset=utf8mb4&parseTime=True&loc=Local"
+}

--- a/controller/comment.go
+++ b/controller/comment.go
@@ -1,17 +1,18 @@
 package controller
 
 import (
+	"TinyTikTok/models"
 	"github.com/gin-gonic/gin"
 	"net/http"
 )
 
 type CommentListResponse struct {
-	Response
+	models.Response
 	CommentList []Comment `json:"comment_list,omitempty"`
 }
 
 type CommentActionResponse struct {
-	Response
+	models.Response
 	Comment Comment `json:"comment,omitempty"`
 }
 
@@ -23,7 +24,7 @@ func CommentAction(c *gin.Context) {
 	if user, exist := usersLoginInfo[token]; exist {
 		if actionType == "1" {
 			text := c.Query("comment_text")
-			c.JSON(http.StatusOK, CommentActionResponse{Response: Response{StatusCode: 0},
+			c.JSON(http.StatusOK, CommentActionResponse{Response: models.Response{StatusCode: 0},
 				Comment: Comment{
 					Id:         1,
 					User:       user,
@@ -32,16 +33,16 @@ func CommentAction(c *gin.Context) {
 				}})
 			return
 		}
-		c.JSON(http.StatusOK, Response{StatusCode: 0})
+		c.JSON(http.StatusOK, models.Response{StatusCode: 0})
 	} else {
-		c.JSON(http.StatusOK, Response{StatusCode: 1, StatusMsg: "User doesn't exist"})
+		c.JSON(http.StatusOK, models.Response{StatusCode: 1, StatusMsg: "User doesn't exist"})
 	}
 }
 
 // CommentList all videos have same demo comment list
 func CommentList(c *gin.Context) {
 	c.JSON(http.StatusOK, CommentListResponse{
-		Response:    Response{StatusCode: 0},
+		Response:    models.Response{StatusCode: 0},
 		CommentList: DemoComments,
 	})
 }

--- a/controller/common.go
+++ b/controller/common.go
@@ -1,9 +1,11 @@
 package controller
 
+/*
 type Response struct {
 	StatusCode int32  `json:"status_code"`
 	StatusMsg  string `json:"status_msg,omitempty"`
 }
+*/
 
 type Video struct {
 	Id            int64  `json:"id,omitempty"`

--- a/controller/favorite.go
+++ b/controller/favorite.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"TinyTikTok/models"
 	"github.com/gin-gonic/gin"
 	"net/http"
 )
@@ -10,16 +11,16 @@ func FavoriteAction(c *gin.Context) {
 	token := c.Query("token")
 
 	if _, exist := usersLoginInfo[token]; exist {
-		c.JSON(http.StatusOK, Response{StatusCode: 0})
+		c.JSON(http.StatusOK, models.Response{StatusCode: 0})
 	} else {
-		c.JSON(http.StatusOK, Response{StatusCode: 1, StatusMsg: "User doesn't exist"})
+		c.JSON(http.StatusOK, models.Response{StatusCode: 1, StatusMsg: "User doesn't exist"})
 	}
 }
 
 // FavoriteList all users have same favorite video list
 func FavoriteList(c *gin.Context) {
 	c.JSON(http.StatusOK, VideoListResponse{
-		Response: Response{
+		Response: models.Response{
 			StatusCode: 0,
 		},
 		VideoList: DemoVideos,

--- a/controller/feed.go
+++ b/controller/feed.go
@@ -1,13 +1,14 @@
 package controller
 
 import (
+	"TinyTikTok/models"
 	"github.com/gin-gonic/gin"
 	"net/http"
 	"time"
 )
 
 type FeedResponse struct {
-	Response
+	models.Response
 	VideoList []Video `json:"video_list,omitempty"`
 	NextTime  int64   `json:"next_time,omitempty"`
 }
@@ -15,7 +16,7 @@ type FeedResponse struct {
 // Feed same demo video list for every request
 func Feed(c *gin.Context) {
 	c.JSON(http.StatusOK, FeedResponse{
-		Response:  Response{StatusCode: 0},
+		Response:  models.Response{StatusCode: 0},
 		VideoList: DemoVideos,
 		NextTime:  time.Now().Unix(),
 	})

--- a/controller/message.go
+++ b/controller/message.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"TinyTikTok/models"
 	"fmt"
 	"github.com/gin-gonic/gin"
 	"net/http"
@@ -14,7 +15,7 @@ var tempChat = map[string][]Message{}
 var messageIdSequence = int64(1)
 
 type ChatResponse struct {
-	Response
+	models.Response
 	MessageList []Message `json:"message_list"`
 }
 
@@ -40,9 +41,9 @@ func MessageAction(c *gin.Context) {
 		} else {
 			tempChat[chatKey] = []Message{curMessage}
 		}
-		c.JSON(http.StatusOK, Response{StatusCode: 0})
+		c.JSON(http.StatusOK, models.Response{StatusCode: 0})
 	} else {
-		c.JSON(http.StatusOK, Response{StatusCode: 1, StatusMsg: "User doesn't exist"})
+		c.JSON(http.StatusOK, models.Response{StatusCode: 1, StatusMsg: "User doesn't exist"})
 	}
 }
 
@@ -55,9 +56,9 @@ func MessageChat(c *gin.Context) {
 		userIdB, _ := strconv.Atoi(toUserId)
 		chatKey := genChatKey(user.Id, int64(userIdB))
 
-		c.JSON(http.StatusOK, ChatResponse{Response: Response{StatusCode: 0}, MessageList: tempChat[chatKey]})
+		c.JSON(http.StatusOK, ChatResponse{Response: models.Response{StatusCode: 0}, MessageList: tempChat[chatKey]})
 	} else {
-		c.JSON(http.StatusOK, Response{StatusCode: 1, StatusMsg: "User doesn't exist"})
+		c.JSON(http.StatusOK, models.Response{StatusCode: 1, StatusMsg: "User doesn't exist"})
 	}
 }
 

--- a/controller/publish.go
+++ b/controller/publish.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"TinyTikTok/models"
 	"fmt"
 	"github.com/gin-gonic/gin"
 	"net/http"
@@ -8,7 +9,7 @@ import (
 )
 
 type VideoListResponse struct {
-	Response
+	models.Response
 	VideoList []Video `json:"video_list"`
 }
 
@@ -17,13 +18,13 @@ func Publish(c *gin.Context) {
 	token := c.PostForm("token")
 
 	if _, exist := usersLoginInfo[token]; !exist {
-		c.JSON(http.StatusOK, Response{StatusCode: 1, StatusMsg: "User doesn't exist"})
+		c.JSON(http.StatusOK, models.Response{StatusCode: 1, StatusMsg: "User doesn't exist"})
 		return
 	}
 
 	data, err := c.FormFile("data")
 	if err != nil {
-		c.JSON(http.StatusOK, Response{
+		c.JSON(http.StatusOK, models.Response{
 			StatusCode: 1,
 			StatusMsg:  err.Error(),
 		})
@@ -35,14 +36,14 @@ func Publish(c *gin.Context) {
 	finalName := fmt.Sprintf("%d_%s", user.Id, filename)
 	saveFile := filepath.Join("./public/", finalName)
 	if err := c.SaveUploadedFile(data, saveFile); err != nil {
-		c.JSON(http.StatusOK, Response{
+		c.JSON(http.StatusOK, models.Response{
 			StatusCode: 1,
 			StatusMsg:  err.Error(),
 		})
 		return
 	}
 
-	c.JSON(http.StatusOK, Response{
+	c.JSON(http.StatusOK, models.Response{
 		StatusCode: 0,
 		StatusMsg:  finalName + " uploaded successfully",
 	})
@@ -51,7 +52,7 @@ func Publish(c *gin.Context) {
 // PublishList all users have same publish video list
 func PublishList(c *gin.Context) {
 	c.JSON(http.StatusOK, VideoListResponse{
-		Response: Response{
+		Response: models.Response{
 			StatusCode: 0,
 		},
 		VideoList: DemoVideos,

--- a/controller/relation.go
+++ b/controller/relation.go
@@ -1,12 +1,13 @@
 package controller
 
 import (
+	"TinyTikTok/models"
 	"github.com/gin-gonic/gin"
 	"net/http"
 )
 
 type UserListResponse struct {
-	Response
+	models.Response
 	UserList []User `json:"user_list"`
 }
 
@@ -15,16 +16,16 @@ func RelationAction(c *gin.Context) {
 	token := c.Query("token")
 
 	if _, exist := usersLoginInfo[token]; exist {
-		c.JSON(http.StatusOK, Response{StatusCode: 0})
+		c.JSON(http.StatusOK, models.Response{StatusCode: 0})
 	} else {
-		c.JSON(http.StatusOK, Response{StatusCode: 1, StatusMsg: "User doesn't exist"})
+		c.JSON(http.StatusOK, models.Response{StatusCode: 1, StatusMsg: "User doesn't exist"})
 	}
 }
 
 // FollowList all users have same follow list
 func FollowList(c *gin.Context) {
 	c.JSON(http.StatusOK, UserListResponse{
-		Response: Response{
+		Response: models.Response{
 			StatusCode: 0,
 		},
 		UserList: []User{DemoUser},
@@ -34,7 +35,7 @@ func FollowList(c *gin.Context) {
 // FollowerList all users have same follower list
 func FollowerList(c *gin.Context) {
 	c.JSON(http.StatusOK, UserListResponse{
-		Response: Response{
+		Response: models.Response{
 			StatusCode: 0,
 		},
 		UserList: []User{DemoUser},
@@ -44,7 +45,7 @@ func FollowerList(c *gin.Context) {
 // FriendList all users have same friend list
 func FriendList(c *gin.Context) {
 	c.JSON(http.StatusOK, UserListResponse{
-		Response: Response{
+		Response: models.Response{
 			StatusCode: 0,
 		},
 		UserList: []User{DemoUser},

--- a/controller/user.go
+++ b/controller/user.go
@@ -1,9 +1,12 @@
 package controller
 
 import (
+	"TinyTikTok/models"
+	"TinyTikTok/service/impl"
 	"github.com/gin-gonic/gin"
+	"log"
 	"net/http"
-	"sync/atomic"
+	"strconv"
 )
 
 // usersLoginInfo use map to store user info, and key is username+password for demo
@@ -21,72 +24,102 @@ var usersLoginInfo = map[string]User{
 
 var userIdSequence = int64(1)
 
-type UserLoginResponse struct {
-	Response
-	UserId int64  `json:"user_id,omitempty"`
-	Token  string `json:"token"`
-}
+/*
+	type UserLoginResponse struct {
+		Response
+		UserId int64  `json:"user_id,omitempty"`
+		Token  string `json:"token"`
+	}
 
-type UserResponse struct {
-	Response
-	User User `json:"user"`
-}
-
+	type UserResponse struct {
+		Response
+		User User `json:"user"`
+	}
+*/
 func Register(c *gin.Context) {
 	username := c.Query("username")
 	password := c.Query("password")
 
-	token := username + password
-
-	if _, exist := usersLoginInfo[token]; exist {
-		c.JSON(http.StatusOK, UserLoginResponse{
-			Response: Response{StatusCode: 1, StatusMsg: "User already exist"},
-		})
-	} else {
-		atomic.AddInt64(&userIdSequence, 1)
-		newUser := User{
-			Id:   userIdSequence,
-			Name: username,
-		}
-		usersLoginInfo[token] = newUser
-		c.JSON(http.StatusOK, UserLoginResponse{
-			Response: Response{StatusCode: 0},
-			UserId:   userIdSequence,
-			Token:    username + password,
-		})
+	err := impl.UserServiceImpl{}.Register(username, password, c)
+	if err != nil {
+		log.Printf("Register Error!")
 	}
+	/*
+		token := username + password
+
+		if _, exist := usersLoginInfo[token]; exist {
+			c.JSON(http.StatusOK, UserLoginResponse{
+				Response: Response{StatusCode: 1, StatusMsg: "User already exist"},
+			})
+		} else {
+			atomic.AddInt64(&userIdSequence, 1)
+			newUser := User{
+				Id:   userIdSequence,
+				Name: username,
+			}
+			usersLoginInfo[token] = newUser
+			c.JSON(http.StatusOK, UserLoginResponse{
+				Response: Response{StatusCode: 0},
+				UserId:   userIdSequence,
+				Token:    username + password,
+			})
+		}
+	*/
 }
 
 func Login(c *gin.Context) {
 	username := c.Query("username")
 	password := c.Query("password")
 
-	token := username + password
-
-	if user, exist := usersLoginInfo[token]; exist {
-		c.JSON(http.StatusOK, UserLoginResponse{
-			Response: Response{StatusCode: 0},
-			UserId:   user.Id,
-			Token:    token,
-		})
-	} else {
-		c.JSON(http.StatusOK, UserLoginResponse{
-			Response: Response{StatusCode: 1, StatusMsg: "User doesn't exist"},
-		})
+	err := impl.UserServiceImpl{}.Login(username, password, c)
+	if err != nil {
+		log.Printf("Login Error !")
 	}
+	/*
+		token := username + password
+
+		if user, exist := usersLoginInfo[token]; exist {
+			c.JSON(http.StatusOK, UserLoginResponse{
+				Response: Response{StatusCode: 0},
+				UserId:   user.Id,
+				Token:    token,
+			})
+		} else {
+			c.JSON(http.StatusOK, UserLoginResponse{
+				Response: Response{StatusCode: 1, StatusMsg: "User doesn't exist"},
+			})
+		}
+	*/
 }
 
 func UserInfo(c *gin.Context) {
 	token := c.Query("token")
+	userId := c.Query("user_id")
 
-	if user, exist := usersLoginInfo[token]; exist {
-		c.JSON(http.StatusOK, UserResponse{
-			Response: Response{StatusCode: 0},
-			User:     user,
+	userIdInt, _ := strconv.ParseInt(userId, 10, 64)
+	user, err := impl.UserServiceImpl{}.UserInfo(userIdInt, token)
+
+	if err != nil {
+		log.Printf(err.Error())
+		c.JSON(http.StatusOK, models.UserResponse{
+			Response: models.Response{StatusCode: 1, StatusMsg: err.Error()},
 		})
 	} else {
-		c.JSON(http.StatusOK, UserResponse{
-			Response: Response{StatusCode: 1, StatusMsg: "User doesn't exist"},
+		c.JSON(http.StatusOK, models.UserResponse{
+			Response: models.Response{StatusCode: 0},
+			User:     *user,
 		})
 	}
+	/*
+		if user, exist := usersLoginInfo[token]; exist {
+			c.JSON(http.StatusOK, UserResponse{
+				Response: Response{StatusCode: 0},
+				User:     user,
+			})
+		} else {
+			c.JSON(http.StatusOK, UserResponse{
+				Response: Response{StatusCode: 1, StatusMsg: "User doesn't exist"},
+			})
+		}
+	*/
 }

--- a/db/MySql.go
+++ b/db/MySql.go
@@ -1,0 +1,29 @@
+package db
+
+import (
+	"TinyTikTok/config"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+	"log"
+	"time"
+)
+
+var GORM *gorm.DB
+
+func CreateGORMDB() {
+	db, err := gorm.Open(mysql.Open(config.Config.Mysql), &gorm.Config{})
+	if err != nil {
+		log.Println("gorm Init Error : ", err)
+	}
+	sqlDb, _ := db.DB()
+	sqlDb.SetMaxOpenConns(100)                // 连接池最大打开连接数
+	sqlDb.SetMaxIdleConns(25)                 // 连接池最大空闲连接数
+	sqlDb.SetConnMaxLifetime(1 * time.Minute) // 最大生存时间
+
+	GORM = db // 赋值给全局变量 GORM
+}
+
+// GetMysqlDB 需要使用数据库的时候直接创建一个连接 调用此方法即可
+func GetMysqlDB() *gorm.DB {
+	return GORM
+}

--- a/main.go
+++ b/main.go
@@ -1,12 +1,18 @@
 package main
 
 import (
+	"TinyTikTok/config"
+	"TinyTikTok/db"
 	"TinyTikTok/router"
 	"TinyTikTok/service"
 	"github.com/gin-gonic/gin"
 )
 
 func main() {
+
+	config.ReadConfig("config/configuration.json") // 先读取配置文件
+	db.CreateGORMDB()                              // 创建 GORM 连接 MySql
+
 	go service.RunMessageServer()
 
 	r := gin.Default()

--- a/models/CommonEntity.go
+++ b/models/CommonEntity.go
@@ -1,0 +1,23 @@
+package models
+
+import (
+	"TinyTikTok/utils"
+	"time"
+)
+
+// CommonEntity 通用实体，鉴于实体内容较少，不再拆分 service 层和 impl 层
+type CommonEntity struct {
+	Id         int64     `json:"id,omitempty"`
+	CreateTime time.Time `json:"create_time,omitempty"`
+	IsDeleted  int64     `json:"is_deleted"`
+}
+
+// NewCommonEntity 创建 CommonEntity 实体的实例对象
+func NewCommonEntity() CommonEntity {
+	sf := utils.NewSnowflake()
+	return CommonEntity{
+		Id:         sf.Generate(),
+		CreateTime: time.Now(),
+		IsDeleted:  0,
+	}
+}

--- a/models/Response.go
+++ b/models/Response.go
@@ -1,0 +1,7 @@
+package models
+
+type Response struct {
+	CommonEntity
+	StatusCode int32  `json:"status_code"`
+	StatusMsg  string `json:"status_msg,omitempty"`
+}

--- a/models/User.go
+++ b/models/User.go
@@ -1,0 +1,17 @@
+package models
+
+type User struct {
+	// ID              int64  `json:"id"`               // 用户id
+	CommonEntity           // 使用 CommonEntity 对象代替 ID
+	Password        string `json:"password"`         // 用户密码
+	Avatar          string `json:"avatar"`           // 用户头像
+	BackgroundImage string `json:"background_image"` // 用户个人页顶部大图
+	FavoriteCount   int64  `json:"favorite_count"`   // 喜欢数
+	FollowCount     int64  `json:"follow_count"`     // 关注总数
+	FollowerCount   int64  `json:"follower_count"`   // 粉丝总数
+	IsFollow        bool   `json:"is_follow"`        // true-已关注，false-未关注
+	Name            string `json:"name"`             // 用户名称
+	Signature       string `json:"signature"`        // 个人简介
+	TotalFavorited  string `json:"total_favorited"`  // 获赞数量
+	WorkCount       int64  `json:"work_count"`       // 作品数
+}

--- a/models/User.go
+++ b/models/User.go
@@ -12,6 +12,10 @@ type User struct {
 	IsFollow        bool   `json:"is_follow"`        // true-已关注，false-未关注
 	Name            string `json:"name"`             // 用户名称
 	Signature       string `json:"signature"`        // 个人简介
-	TotalFavorited  string `json:"total_favorited"`  // 获赞数量
+	TotalFavorited  int64  `json:"total_favorited"`  // 获赞数量
 	WorkCount       int64  `json:"work_count"`       // 作品数
+}
+
+func (table *User) TableName() string {
+	return "user"
 }

--- a/models/UserLoginResponse.go
+++ b/models/UserLoginResponse.go
@@ -1,0 +1,7 @@
+package models
+
+type UserLoginResponse struct {
+	Response
+	UserId int64  `json:"user_id,omitempty"`
+	Token  string `json:"token"`
+}

--- a/models/UserResponse.go
+++ b/models/UserResponse.go
@@ -1,0 +1,6 @@
+package models
+
+type UserResponse struct {
+	Response
+	User User `json:"user"`
+}

--- a/service/UserService.go
+++ b/service/UserService.go
@@ -1,0 +1,20 @@
+package service
+
+import (
+	"TinyTikTok/models"
+	"github.com/gin-gonic/gin"
+)
+
+type UserService interface {
+	GetUserById(Id int64) (models.User, error) // 通过 Id 查询用户
+
+	GetUserByName(name string) (models.User, error) // 通过 Name 查询用户
+
+	SaveUser(user models.User) error // 将用户存储在数据库中
+
+	Register(username string, password string, context *gin.Context) error // 注册
+
+	Login(username string, password string, context *gin.Context) error // 登录
+
+	UserInfo(userId int64, token string) (*models.User, error) // 通过用户 ID 获取用户信息
+}

--- a/service/impl/UserServiceImpl.go
+++ b/service/impl/UserServiceImpl.go
@@ -1,0 +1,114 @@
+package impl
+
+import (
+	"TinyTikTok/db"
+	"TinyTikTok/models"
+	"errors"
+	"github.com/gin-gonic/gin"
+	"golang.org/x/crypto/bcrypt"
+	"log"
+	"net/http"
+)
+
+type UserServiceImpl struct {
+}
+
+func (userService UserServiceImpl) GetUserById(Id int64) (models.User, error) {
+	var user models.User
+
+	err := db.GetMysqlDB().Where("id = ? AND is_deleted != ?", Id, 1).First(&user).Error
+	if err != nil {
+		log.Printf("方法 GetUserById() 失败 %v", err)
+		return user, err
+	}
+	return user, nil
+}
+
+func (userService UserServiceImpl) GetUserByName(name string) (models.User, error) {
+	var user models.User
+
+	err := db.GetMysqlDB().Where("name = ? AND is_deleted != ?", name, 1).First(&user).Error
+	if err != nil {
+		log.Printf("方法 GetUserByName() 失败 %v", err)
+		return user, err
+	}
+	return user, nil
+}
+
+func (userService UserServiceImpl) SaveUser(user models.User) error {
+	err := db.GetMysqlDB().Create(&user).Error
+	if err != nil {
+		log.Printf("方法 SaveUser() 失败 %v", err)
+		return err
+	}
+	return nil
+}
+
+func (userService UserServiceImpl) Register(username string, password string, context *gin.Context) error {
+	_, errName := userService.GetUserByName(username)
+	if errName == nil { // 为空说明查询没报错，也就是查到了，因此用户名重复
+		context.JSON(http.StatusBadRequest, models.UserLoginResponse{
+			Response: models.Response{StatusCode: 1, StatusMsg: "用户名重复"},
+		})
+		return nil
+	}
+
+	// 密码加密
+	encrypt, _ := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	password = string(encrypt)
+
+	newUser := models.User{ // 新增一个用户的实例对象，保存基础信息
+		CommonEntity: models.NewCommonEntity(),
+		Name:         username,
+		Password:     password,
+	}
+
+	err := userService.SaveUser(newUser) // 存到数据库中
+	if err != nil {
+		context.JSON(http.StatusInternalServerError, models.UserLoginResponse{
+			Response: models.Response{StatusCode: 1, StatusMsg: "无法保存用户！"},
+		})
+	} else {
+		context.JSON(http.StatusOK, models.UserLoginResponse{
+			Response: models.Response{StatusCode: 0},
+			UserId:   newUser.Id,
+		})
+	}
+	return nil
+}
+
+func (userService UserServiceImpl) Login(username string, password string, context *gin.Context) error {
+	// 首先查询是否存在此用户
+	user, err := userService.GetUserByName(username)
+	if err != nil {
+		context.JSON(http.StatusBadRequest, models.UserLoginResponse{
+			Response: models.Response{StatusCode: 1, StatusMsg: "用户不存在，请注册!"},
+		})
+		return nil
+	}
+	// 对密码解密，并与从数据库查询到的信息做对比
+	pwdErr := bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(password))
+	if pwdErr != nil {
+		context.JSON(http.StatusOK, models.UserLoginResponse{
+			Response: models.Response{StatusCode: 1, StatusMsg: "密码错误！"},
+		})
+		return pwdErr
+	}
+	// TODO: 生成和解析 token 的函数待实现，放在 utils 层中
+	token := ""
+	// 登录成功
+	context.JSON(http.StatusOK, models.UserLoginResponse{
+		Response: models.Response{StatusCode: 0, StatusMsg: "登录成功！"},
+		UserId:   user.Id,
+		Token:    token,
+	})
+	return nil
+}
+
+func (userService UserServiceImpl) UserInfo(userId int64, token string) (*models.User, error) {
+	user, err := userService.GetUserById(userId)
+	if err != nil {
+		return nil, errors.New("用户不存在！")
+	}
+	return &user, nil
+}

--- a/utils/Snowflake.go
+++ b/utils/Snowflake.go
@@ -1,0 +1,49 @@
+package utils
+
+import (
+	"sync"
+	"time"
+)
+
+// Snowflake 结构体
+type Snowflake struct {
+	mu         sync.Mutex // 互斥锁
+	timestamp  int64      // 时间戳
+	sequenceID int64      // 序列号
+	machineID  int64      // 机器ID
+}
+
+// 饿汉式创建唯一的 Snowflake 实例
+var snowflake = &Snowflake{
+	timestamp:  0,
+	sequenceID: 1,
+	machineID:  0,
+}
+
+// NewSnowflake 函数，返回一个 Snowflake 实例
+func NewSnowflake() *Snowflake {
+	return snowflake
+}
+
+// Generate 生成唯一 ID
+func (s *Snowflake) Generate() int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now().UnixNano() / int64(time.Millisecond) // 获取当前时间戳(毫秒)
+	if s.timestamp == now {                                // 如果当前时间戳和上次生成时间戳相同，则序列号增 1
+		s.sequenceID = (s.sequenceID + 1) & 4095 // 确保序列号不溢出(4095 = 2^12 - 1表明序列号占12位)
+		if s.sequenceID == 0 {
+			// 序列号溢出，等待下一毫秒
+			for now <= s.timestamp {
+				now = time.Now().UnixNano() / int64(time.Millisecond)
+			}
+		}
+	} else {
+		s.sequenceID = 0 // 否则，重置序列号为 0
+	}
+	s.timestamp = now // 更新时间戳为当前时间
+
+	ID := (now << 22) | (s.machineID << 10) | s.sequenceID // 生成 ID
+	return ID
+}


### PR DESCRIPTION
1. 添加 `utils` 层并新增雪花算法，用于实现生成唯一用户标识符
2. 添加 `config` 文件夹，用于存放数据库连接的相关配置文件
3. 添加 `models` 层
   1. 添加**通用实体**类，用于记录用户 `id` 、创建时间`create_time`和是否被删除 `is_deleted`，并将此类作为 `user` 的一部分
   2. 解耦原 `common.go` 中的 `Response` 类
   3. 解耦原 `common.go` 中的 `UserLoginResponse` 类
4. 添加 `db` 层，用于实现数据库的连接操作
   1. 实现了 `MySql` 数据库的连接与连接池的创立，更新 `main.go` 中的内容
5. 解耦原 `user.go` 中的登录注册，在 `service` 层新增 `UserService` 的接口
6. 实现 `UserService` 接口的相关函数，重写了登录注册逻辑